### PR TITLE
fix: use hostname-based domain instead of hardcoded halos.local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,11 @@ Docker image that advertises `*.halos.local` subdomains via Avahi/mDNS. Monitors
 
 ### Container Labels
 
-Containers can set `halos.subdomain=auth` to advertise `auth.halos.local`.
+Containers can set `halos.subdomain=auth` to advertise `auth.<hostname>.local`.
 
-### Environment Variables
+### Domain
 
-- `HALOS_DOMAIN` - Base domain (default: `halos.local`)
+The domain is automatically derived from the system hostname: `<hostname>.local`
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ services:
     network_mode: host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    environment:
-      - HALOS_DOMAIN=halos.local  # Optional, default is halos.local
+      - /var/run/dbus:/var/run/dbus
 ```
+
+The domain is automatically derived from the system hostname: `<hostname>.local`
 
 ## Container Labels
 
@@ -32,7 +33,7 @@ services:
   authelia:
     image: authelia/authelia:4.39
     labels:
-      - "halos.subdomain=auth"  # Advertises auth.halos.local
+      - "halos.subdomain=auth"  # Advertises auth.<hostname>.local
 ```
 
 ## How It Works

--- a/publish-subdomains.sh
+++ b/publish-subdomains.sh
@@ -8,7 +8,8 @@
 set -e
 
 # Configuration
-DOMAIN="${HALOS_DOMAIN:-halos.local}"
+HOSTNAME_SHORT=$(hostname -s 2>/dev/null || hostname | cut -d. -f1)
+DOMAIN="${HOSTNAME_SHORT}.local"
 PID_DIR="/tmp/mdns-publisher"
 
 # Create PID directory


### PR DESCRIPTION
## Summary
- Domain is now automatically derived from the system hostname: `<hostname>.local`
- Removes hardcoded `halos.local` and `HALOS_DOMAIN` environment variable
- Follows standard mDNS convention
- Avoids conflicts when multiple HaLOS devices are on the same network

## Changes
- `publish-subdomains.sh`: Use `$(hostname -s).local` instead of `HALOS_DOMAIN`
- `README.md`: Update documentation
- `AGENTS.md`: Update documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)