### PR TITLE
refactor: remove amd64 platform support, build ARM64 only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: false
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
Remove amd64 platform from Docker image builds. HaLOS only runs on ARM64 devices (Raspberry Pi), so building amd64 images is counterproductive and wastes CI resources.

## Changes
- `main.yml`: Changed platforms from `linux/amd64,linux/arm64` to `linux/arm64`
- `release.yml`: Changed platforms from `linux/amd64,linux/arm64` to `linux/arm64`
- `pr.yml`: Changed platforms from `linux/amd64,linux/arm64` to `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)