### PR TITLE
fix: use avahi-publish-address --no-reverse to avoid local name collision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Native systemd service (Rust) that advertises container subdomains via Avahi/mDN
 
 1. Waits for Docker daemon to be available (graceful degradation)
 2. Scans running containers for `halos.subdomain` label
-3. Spawns `avahi-publish -a` subprocesses for each subdomain
+3. Spawns `avahi-publish-address --no-reverse` subprocesses for each subdomain
 4. Monitors Docker events via bollard async stream
 5. Starts/stops avahi-publish processes as containers start/stop
 6. Periodic health checks to restart failed avahi-publish processes

--- a/src/avahi_manager.rs
+++ b/src/avahi_manager.rs
@@ -1,6 +1,6 @@
 //! Avahi publish subprocess management
 //!
-//! Manages `avahi-publish -a` subprocesses for mDNS record publication.
+//! Manages `avahi-publish-address` subprocesses for mDNS record publication.
 //! Each subdomain gets its own subprocess that is tracked by container ID.
 
 use std::collections::HashMap;
@@ -103,9 +103,10 @@ impl AvahiManager {
 
         info!("Publishing {} -> {}", fqdn, self.host_ip);
 
-        // Spawn avahi-publish process
-        let child = Command::new("avahi-publish")
-            .args(["-a", &fqdn, &self.host_ip])
+        // Spawn avahi-publish-address process with --no-reverse to avoid
+        // "Local name collision" errors when publishing subdomains of the host's domain
+        let child = Command::new("avahi-publish-address")
+            .args(["--no-reverse", &fqdn, &self.host_ip])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
             .spawn()?;


### PR DESCRIPTION
## Summary

- Fix `avahi-publish -a` failing with "Local name collision" when publishing subdomains of the host's own domain
- Change command from `avahi-publish -a` to `avahi-publish-address --no-reverse`
- Update documentation to reflect the command change

## Root Cause

`avahi-publish -a` (shorthand for `avahi-publish-address`) has issues when publishing subdomains of the local hostname. For example, `auth.halos.local` fails when the hostname is `halos`. Using the full `avahi-publish-address` command with `--no-reverse` flag works correctly by preventing publication of a reverse DNS record that was causing the collision.

## Test plan

- [x] All existing unit tests pass
- [x] Lint and clippy checks pass
- [ ] Manual testing on device with Docker containers using `halos.subdomain` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)