### PR TITLE
fix(ci): remove undefined package-name input from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ jobs:
   publish-stable:
     uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
     with:
-      package-name: halos-mdns-publisher
       apt-distro: trixie
       apt-component: main
     secrets:


### PR DESCRIPTION
## Summary

- Fixed release workflow startup_failure caused by passing undefined `package-name` input to the `publish-stable.yml` shared workflow
- The shared workflow only accepts: `apt-distro`, `apt-component`, `apt-repository`, and `version-pattern`

## Root Cause

The `v0.2.0+1` release failed with `startup_failure` because GitHub Actions rejects workflows that pass undefined inputs to reusable workflows.

## Test plan

- [ ] Merge this PR
- [ ] Re-publish the v0.2.0+1 release (delete and recreate, or manually trigger the APT dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)