### PR TITLE
fix: use deb-systemd-helper for service enablement

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -24,10 +24,20 @@ case "$1" in
     configure)
         # Configure mDNS resolution for multi-label hostnames
         configure_nsswitch
-        # Service enablement is handled by dh_installsystemd via #DEBHELPER#
+
+        # Enable the systemd service
+        # Using deb-systemd-helper which works in chroots during image build
+        if command -v deb-systemd-helper >/dev/null 2>&1; then
+            deb-systemd-helper unmask 'halos-mdns-publisher.service' >/dev/null || true
+            deb-systemd-helper enable 'halos-mdns-publisher.service' >/dev/null || true
+        fi
+
+        # Start the service if systemd is running
+        if [ -d /run/systemd/system ]; then
+            systemctl --system daemon-reload >/dev/null || true
+            systemctl start halos-mdns-publisher.service >/dev/null || true
+        fi
         ;;
 esac
-
-#DEBHELPER#
 
 exit 0


### PR DESCRIPTION
## Summary

Use `deb-systemd-helper` for service enablement instead of relying on `#DEBHELPER#` token expansion.

## Root Cause

The build uses `dpkg-deb --build` directly, not `dpkg-buildpackage`, so debhelper tokens like `#DEBHELPER#` are never expanded. The previous postinst relied on this token being replaced with proper `deb-systemd-helper` calls.

Additionally, even if the token had worked, the old fallback approach using `systemctl enable` fails in chroots during image build where systemd isn't running.

## Changes

Replace the `#DEBHELPER#` reliance with explicit `deb-systemd-helper` calls:
- `deb-systemd-helper unmask` - ensure service isn't masked
- `deb-systemd-helper enable` - enable the service (works in chroots)
- `systemctl start` - start service if systemd is running (runtime installs)

## Test plan

- [ ] Build package via CI
- [ ] Install on fresh HaLOS image
- [ ] Verify `systemctl status halos-mdns-publisher` shows enabled and active after boot
- [ ] Verify mDNS subdomains resolve (e.g., `ping auth.halos.local`)

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)