### PR TITLE
fix: capture timestamp before scan to avoid missing container events

### DIFF
--- a/src/container_watcher.rs
+++ b/src/container_watcher.rs
@@ -144,8 +144,13 @@ impl ContainerWatcher {
     ///
     /// Returns an async stream of optional ContainerEvents.
     /// Returns None for containers that don't have the subdomain label on start.
+    ///
+    /// The `since` parameter specifies the Unix timestamp from which to start
+    /// receiving events. This should be captured before scanning containers
+    /// to avoid missing events that occur during the scan.
     pub async fn watch_events(
         &self,
+        since: Option<i64>,
     ) -> impl futures_util::Stream<Item = Result<Option<ContainerEvent>>> + '_ {
         let mut filters = HashMap::new();
         filters.insert("type".to_string(), vec!["container".to_string()]);
@@ -160,7 +165,7 @@ impl ContainerWatcher {
         );
 
         let options = EventsOptions {
-            since: None,
+            since: since.map(|t| t.to_string()),
             until: None,
             filters,
         };


### PR DESCRIPTION
## Summary
- Fix race condition where containers starting during initial scan were missed
- Capture Unix timestamp before scanning containers
- Pass timestamp to Docker event stream subscription via `since` parameter
- Ensures all container start events from scan start time onwards are captured

## Root Cause
The Docker event stream was subscribed with `since: None`, meaning it only received events occurring *after* subscription. If a container started between the initial scan completing and the event subscription starting, it would be missed entirely.

## Test Results
Tested on halos.local with fresh boot simulation:
```
13:59:17 - Initial scan found 1 container (signalk)
13:59:18 - Started watching for Docker events (with since=scan_start_time)
13:59:24 - Docker event captured: start container 'authelia'
13:59:24 - Container 'authelia' started with subdomain 'auth'
13:59:26 - Verified: auth.halos.local resolves to 10.84.77.20
```

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)