### PR TITLE
chore: add changelog check pre-commit hook

### DIFF
--- a/.github/scripts/check-changelog-edits.sh
+++ b/.github/scripts/check-changelog-edits.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook to prevent direct debian/changelog edits.
+# Changelog updates must go through ./run bumpversion which uses dch
+# to ensure proper RFC 2822 date formatting.
+#
+# Bypass: SKIP_CHANGELOG_CHECK=1 git commit ...
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Allow bypass for ./run bumpversion (via env var)
+if [[ "${SKIP_CHANGELOG_CHECK:-}" == "1" ]]; then
+    exit 0
+fi
+
+# Check if any debian/changelog files are staged
+CHANGELOG_FILES=$(git diff --cached --name-only | grep -E 'debian/changelog$' || true)
+
+if [[ -n "$CHANGELOG_FILES" ]]; then
+    echo "ERROR: Direct debian/changelog edits are not allowed."
+    echo ""
+    echo "Staged changelog files:"
+    echo "$CHANGELOG_FILES" | sed 's/^/  /'
+    echo ""
+    echo "Why: Manual changelog edits often have RFC 2822 date formatting errors"
+    echo "(wrong weekday for date). The dch tool handles this correctly."
+    echo ""
+    echo "Solution: Use './run bumpversion [patch|minor|major]' which:"
+    echo "  1. Updates VERSION file"
+    echo "  2. Uses dch to update debian/changelog with correct dates"
+    echo "  3. Commits the changes"
+    echo ""
+    echo "If you need to bypass this check (e.g., fixing a changelog):"
+    echo "  SKIP_CHANGELOG_CHECK=1 git commit ..."
+    echo ""
+    exit 1
+fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,3 +22,7 @@ pre-commit:
     check-hostnames:
       run: .github/scripts/check-hardcoded-hostnames.sh
       fail_text: "Hard-coded hostname references found. See error above for details."
+
+    check-changelog:
+      run: .github/scripts/check-changelog-edits.sh
+      fail_text: "Direct debian/changelog edits are not allowed. Use './run bumpversion' instead."


### PR DESCRIPTION
## Summary

Adds lefthook hook to prevent direct debian/changelog edits. Changelog updates must go through `./run bumpversion` to ensure proper RFC 2822 date formatting.

Part of workspace-wide changelog policy from hatlabs/halos-distro#74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)