### PR TITLE
fix: rename changelog.gz to changelog.Debian.gz per Debian policy

### DIFF
--- a/.github/scripts/build-deb-package.sh
+++ b/.github/scripts/build-deb-package.sh
@@ -88,9 +88,18 @@ docker run --rm \
             chmod 644 "$PKG_DIR/usr/share/lintian/overrides/${PACKAGE_NAME}"
         fi
 
-        # Create changelog.gz (use -n for reproducible builds)
+        # Create changelog file (use -n for reproducible builds)
+        # Debian policy:
+        # - Native packages (version without dash, e.g., "1.0") use changelog.gz
+        # - Non-native packages (version with dash, e.g., "1.0-1") use changelog.Debian.gz
         if [ -f debian/changelog ]; then
-            gzip -9 -n -c debian/changelog > "$PKG_DIR/usr/share/doc/${PACKAGE_NAME}/changelog.gz"
+            if [[ "$DEB_VERSION" == *-* ]]; then
+                # Non-native package (has revision number)
+                gzip -9 -n -c debian/changelog > "$PKG_DIR/usr/share/doc/${PACKAGE_NAME}/changelog.Debian.gz"
+            else
+                # Native package (no revision number)
+                gzip -9 -n -c debian/changelog > "$PKG_DIR/usr/share/doc/${PACKAGE_NAME}/changelog.gz"
+            fi
         fi
 
         # Copy copyright file


### PR DESCRIPTION
## Summary

- Fix lintian error `debian-changelog-file-missing-or-wrong-name` that caused main branch CI to fail
- Rename `changelog.gz` to `changelog.Debian.gz` per Debian policy requirements

## Context

The main branch CI workflow has been failing since PR #27 was merged due to lintian checks. The error was:
```
E: halos-mdns-publisher: debian-changelog-file-missing-or-wrong-name
```

Debian policy requires packages without separate upstream changelogs to name their changelog file `changelog.Debian.gz`, not `changelog.gz`.

## Test plan

- [ ] PR checks pass (lintian should now succeed)
- [ ] Merge to main triggers successful CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)